### PR TITLE
Change order of widgets in spaghetti; fix labels; enhance toggle

### DIFF
--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -316,7 +316,7 @@ ui_g_boxplot <- function(id, ...) {
       if (length(a$hline_vars) > 0) {
         optionalSelectInput(
           ns("hline_vars"),
-          label = "Add Range Line(s):",
+          label = "Add Horizontal Range Line(s):",
           choices = a$hline_vars,
           selected = NULL,
           multiple = TRUE

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -297,29 +297,29 @@ g_ui_spaghettiplot <- function(id, ...) {
         c("None" = "NONE", "Mean" = "MEAN", "Median" = "MEDIAN"),
         inline = TRUE
       ),
+      templ_ui_constraint(ns), # required by constr_anl_chunks
       if (length(a$hline_vars) > 0) {
         optionalSelectInput(
           ns("hline_vars"),
-          label = "Add Range Line(s):",
+          label = "Add Horizontal Range Line(s):",
           choices = a$hline_vars,
           selected = NULL,
           multiple = TRUE
         )
       },
       ui_arbitrary_lines(id = ns("hline_arb"), a$hline_arb, a$hline_arb_label, a$hline_arb_color),
-      templ_ui_constraint(ns), # required by constr_anl_chunks
-      toggle_slider_ui(
-        ns("yrange_scale"),
-        label = "Y-Axis Range Zoom",
-        min = -1000000,
-        max = 1000000,
-        value = c(-1000000, 1000000)
-      ),
       panel_group(
         panel_item(
           title = "Plot Aesthetic Settings",
           div(
             style = "padding: 0px;",
+            toggle_slider_ui(
+              ns("yrange_scale"),
+              label = "Y-Axis Range Zoom",
+              min = -1000000,
+              max = 1000000,
+              value = c(-1000000, 1000000)
+            ),
             div(
               style = "display: inline-block;vertical-align:middle; width: 175px;",
               tags$b("Number of Plots Per Row:")

--- a/R/toggleable_slider.R
+++ b/R/toggleable_slider.R
@@ -91,7 +91,7 @@ toggle_slider_ui <- function(id,
   ns <- NS(id)
   div(
     shinyjs::useShinyjs(),
-    actionButton(ns("toggle"), "Toggle"),
+    actionButton(ns("toggle"), "Toggle", class = "btn-xs", style = "float: right;"),
     show_or_not(slider_initially)(
       sliderInput(
         ns("slider"),


### PR DESCRIPTION
closes #103

- change the order in spaghetti as in the ticket
- move y axis range zoom into the Plot Aesthetic Settings as in the other modules
- change few label to make everything more consistent
- enhance toggle a little:

previously:
![image](https://user-images.githubusercontent.com/12943682/150571297-361a3194-aa97-45b1-abb2-271d104c67d6.png)

now after changes:
![image](https://user-images.githubusercontent.com/12943682/150571361-3af69d27-df1b-433b-9238-263be9ad2d5b.png)

On a small width it's not looking that nice but kind of similar to the previous state
![image](https://user-images.githubusercontent.com/12943682/150571539-d056e720-8648-4fc5-80ae-abed676b23e4.png)

