### PR TITLE
type coercion warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.
 
+### Miscellaneous
+* Fixed minor type coercion warning in `srv_arbitrary_lines`.
+
 # teal.goshawk 0.1.13
 
 ### Miscellaneous

--- a/R/utils.R
+++ b/R/utils.R
@@ -459,7 +459,7 @@ srv_arbitrary_lines <- function(id) {
             )
           )
         }
-        if (length(line_arb_color) == 0 || all(line_arb_color %in% "")) {
+        if (length(line_arb_color) == 0 || all(line_arb_color == "")) {
           line_arb_color <- "red"
         } else {
           validate(

--- a/R/utils.R
+++ b/R/utils.R
@@ -459,7 +459,7 @@ srv_arbitrary_lines <- function(id) {
             )
           )
         }
-        if (length(line_arb_color) == 0 || line_arb_color == "") {
+        if (length(line_arb_color) == 0 || all(line_arb_color %in% "")) {
           line_arb_color <- "red"
         } else {
           validate(


### PR DESCRIPTION
closes https://github.com/insightsengineering/teal.goshawk/issues/169.

The warning was caused by `line_arb_color` potentially having more than one element.
