### PR TITLE
161 Implement `nestcolor` in `teal.goshawk`

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -41,6 +41,8 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/roxygen.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      auto-update: true
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main
@@ -68,3 +70,5 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Style Check 👗
     uses: insightsengineering/r.pkg.template/.github/workflows/style.yaml@main
+    with:
+      auto-update: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.goshawk
 Title: Longitudinal visualization teal modules
-Version: 0.1.13.9007
+Version: 0.1.13.9008
 Date: 2022-06-09
 Authors@R: c(
     person("Nick", "Paszty", , "nick.paszty@gene.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.goshawk
 Title: Longitudinal visualization teal modules
-Version: 0.1.13.9004
+Version: 0.1.13.9005
 Date: 2022-06-09
 Authors@R: c(
     person("Nick", "Paszty", , "nick.paszty@gene.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.goshawk
 Title: Longitudinal visualization teal modules
-Version: 0.1.13.9005
+Version: 0.1.13.9006
 Date: 2022-06-09
 Authors@R: c(
     person("Nick", "Paszty", , "nick.paszty@gene.com", role = c("aut", "cre")),
@@ -62,11 +62,11 @@ Remotes:
     insightsengineering/scda@*release,
     insightsengineering/teal.code@*release,
     insightsengineering/teal.logger@*release,
+    insightsengineering/teal.reporter@*release,
     insightsengineering/teal.transform@*release,
     insightsengineering/teal.widgets@*release,
     insightsengineering/teal@*release,
-    insightsengineering/tern@*release,
-    insightsengineering/teal.reporter@*release
+    insightsengineering/tern@*release
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,6 @@ Suggests:
     testthat (>= 2.0),
     utils
 Remotes:
-    insightsengineering/nestcolor@*release,
     insightsengineering/scda.2021@*release,
     insightsengineering/scda@*release,
     insightsengineering/teal.code@*release,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,8 @@ Remotes:
     insightsengineering/teal.transform@*release,
     insightsengineering/teal.widgets@*release,
     insightsengineering/teal@*release,
-    insightsengineering/tern@*release
+    insightsengineering/tern@*release,
+    insightsengineering/teal.reporter@*release
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: teal.goshawk
 Title: Longitudinal visualization teal modules
-Version: 0.1.13.9006
+Version: 0.1.13.9007
 Date: 2022-06-09
 Authors@R: c(
     person("Nick", "Paszty", , "nick.paszty@gene.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.goshawk 0.1.13.9007
+# teal.goshawk 0.1.13.9008
 
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.
+* Added `plot_relative_height_value` argument to `tm_g_gh_lineplot` to control initial value of the relative plot height slider. 
 
 ### Miscellaneous
 * Fixed minor type coercion warning in `srv_arbitrary_lines`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.
 
+### Miscellaneous
+* Fixed minor type coercion warning in `srv_arbitrary_lines`.
+
 # teal.goshawk 0.1.13
 
 ### Miscellaneous

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.
 * Added `plot_relative_height_value` argument to `tm_g_gh_lineplot` to control initial value of the relative plot height slider. 
-* Implemented `nestcolor` with slight refactoring to `tm_g_gh_lineplot`. Added `nestcolor` in examples without custom color manuals.
+* Implemented `nestcolor` with slight refactoring to `tm_g_gh_lineplot`. Added `nestcolor` in examples with no custom color manuals.
 
 ### Miscellaneous
 * Fixed minor type coercion warning in `srv_arbitrary_lines`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.goshawk 0.1.13.9004
+# teal.goshawk 0.1.13.9005
 
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.goshawk 0.1.13.9005
+# teal.goshawk 0.1.13.9006
 
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.goshawk 0.1.13.9006
+# teal.goshawk 0.1.13.9007
 
 ### Enhancements
 * Added `teal.reporter` reporting into all the package modules.

--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -41,7 +41,8 @@
 #' @param count_threshold minimum count of observations (as listed in the output table) to plot
 #' nodes on the graph
 #' @param table_font_size controls the font size of values in the table
-#'
+#' @param plot_relative_height_value numeric value between 500 and 5000 for controlling the starting value
+#' of the relative plot height slider
 #' @author Wenyi Liu (luiw2) wenyi.liu@roche.com
 #' @author Balazs Toth (tothb2) toth.balazs@gene.com
 #'
@@ -140,7 +141,7 @@
 #'       trt_group = choices_selected(c("ARM", "ACTARM"), "ARM"),
 #'       hline_arb = c(20.5, 19.5),
 #'       hline_arb_color = c("red", "green"),
-#'       hline_arb_label = c("A", "B"),
+#'       hline_arb_label = c("A", "B")
 #'     )
 #'   )
 #' )
@@ -175,7 +176,8 @@ tm_g_gh_lineplot <- function(label,
                              pre_output = NULL,
                              post_output = NULL,
                              count_threshold = 0,
-                             table_font_size = c(12, 4, 20)) {
+                             table_font_size = c(12, 4, 20),
+                             plot_relative_height_value = 1000) {
   logger::log_info("Initializing tm_g_gh_lineplot")
   checkmate::assert_class(param, "choices_selected")
   checkmate::assert_class(xaxis_var, "choices_selected")
@@ -195,6 +197,9 @@ tm_g_gh_lineplot <- function(label,
     lower = table_font_size[2], upper = table_font_size[3],
     null.ok = TRUE, .var.name = "table_font_size"
   )
+
+  checkmate::assert_number(plot_relative_height_value, lower = 500, upper = 5000)
+
   checkmate::assert_number(count_threshold)
   validate_line_arb_arg(hline_arb, hline_arb_color, hline_arb_label)
   args <- as.list(environment())
@@ -272,7 +277,7 @@ ui_lineplot <- function(id, ...) {
           min = 500,
           max = 5000,
           step = 50,
-          value = 1000,
+          value = a$plot_relative_height_value,
           ticks = FALSE
         ),
       ),

--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -166,8 +166,10 @@ tm_g_gh_lineplot <- function(label,
                              hline_arb = numeric(0),
                              hline_arb_color = "red",
                              hline_arb_label = "Horizontal line",
-                             color_manual = c(getOption("ggplot2.discrete.colour"),
-                                              c("#ff0000", "#008000", "#4ca3dd", "#8a2be2"))[1:4],
+                             color_manual = c(
+                               getOption("ggplot2.discrete.colour"),
+                               c("#ff0000", "#008000", "#4ca3dd", "#8a2be2")
+                             )[1:4],
                              xtick = ggplot2::waiver(),
                              xlabel = xtick,
                              rotate_xlab = FALSE,

--- a/R/utils.R
+++ b/R/utils.R
@@ -459,7 +459,7 @@ srv_arbitrary_lines <- function(id) {
             )
           )
         }
-        if (length(line_arb_color) == 0 || line_arb_color == "") {
+        if (length(line_arb_color) == 0 || all(line_arb_color == "")) {
           line_arb_color <- "red"
         } else {
           validate(

--- a/man/tm_g_gh_lineplot.Rd
+++ b/man/tm_g_gh_lineplot.Rd
@@ -33,7 +33,8 @@ tm_g_gh_lineplot(
   pre_output = NULL,
   post_output = NULL,
   count_threshold = 0,
-  table_font_size = c(12, 4, 20)
+  table_font_size = c(12, 4, 20),
+  plot_relative_height_value = 1000
 )
 }
 \arguments{
@@ -107,6 +108,9 @@ into context. For example the \code{\link[shiny:helpText]{shiny::helpText()}} el
 nodes on the graph}
 
 \item{table_font_size}{controls the font size of values in the table}
+
+\item{plot_relative_height_value}{numeric value between 500 and 5000 for controlling the starting value
+of the relative plot height slider}
 }
 \value{
 \code{shiny} object
@@ -205,7 +209,7 @@ app <- teal::init(
       trt_group = choices_selected(c("ARM", "ACTARM"), "ARM"),
       hline_arb = c(20.5, 19.5),
       hline_arb_color = c("red", "green"),
-      hline_arb_label = c("A", "B"),
+      hline_arb_label = c("A", "B")
     )
   )
 )


### PR DESCRIPTION
Closes #161 

To avoid errors, needs to be merged simultaneously with insightsengineering/nestcolor#20, https://github.com/insightsengineering/goshawk/pull/165, https://github.com/insightsengineering/osprey/pull/92, https://github.com/insightsengineering/teal.osprey/pull/162, and https://github.com/insightsengineering/teal.modules.general/pull/428.