### PR TITLE
Update font awesome icon labels for FA 6

### DIFF
--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -276,7 +276,7 @@ ui_lineplot <- function(id, ...) {
                 "change the total size of the plot and table(s)\nuse",
                 "the plot resizing controls available at the top right of the plot."
               ),
-            icon("info-circle")
+            icon("circle-info")
           ),
           min = 500,
           max = 5000,


### PR DESCRIPTION
Update font awesome icon labels for FA 6, to avoid warnings like:

```
This Font Awesome icon ('some icon') does not exist:
* if providing a custom `html_dependency` these `name` checks can 
  be deactivated with `verify_fa = FALSE`
```