### PR TITLE
release 0.1.15 [skip vbump] [skip spelling]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.goshawk
 Title: Longitudinal Visualization `teal` Modules
-Version: 0.1.14.9021
-Date: 2023-08-09
+Version: 0.1.15
+Date: 2023-08-11
 Authors@R: c(
     person("Nick", "Paszty", , "nick.paszty@gene.com", role = c("aut", "cre")),
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Depends:
     goshawk (>= 0.1.15),
     R (>= 3.6),
     shiny,
-    teal (>= 0.13.0.9027)
+    teal (>= 0.14.0)
 Imports:
     checkmate,
     colourpicker,
@@ -44,18 +44,18 @@ Imports:
     shinyjs,
     shinyvalidate,
     stats,
-    teal.code (>= 0.3.0.9009),
+    teal.code (>= 0.4.0),
     teal.logger (>= 0.1.1),
-    teal.reporter (>= 0.1.1.9020),
-    teal.transform (>= 0.3.0.9009),
-    teal.widgets (>= 0.3.0.9010),
+    teal.reporter (>= 0.2.0),
+    teal.transform (>= 0.4.0),
+    teal.widgets (>= 0.4.0),
     tidyr
 Suggests:
     knitr,
     nestcolor (>= 0.1.0),
     rmarkdown,
     stringr,
-    teal.data (>= 0.2.0.9007),
+    teal.data (>= 0.3.0),
     tern (>= 0.7.10),
     testthat (>= 2.0),
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Description: Modules that produce web interfaces through which
     with levels 'Y', 'N' or NA.
 License: Apache License 2.0 | file LICENSE
 Depends:
-    goshawk (>= 0.1.14),
+    goshawk (>= 0.1.15),
     R (>= 3.6),
     shiny,
     teal (>= 0.13.0.9027)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Depends:
     goshawk (>= 0.1.14),
     R (>= 3.6),
     shiny,
-    teal (>= 0.12.0)
+    teal (>= 0.13.0.9027)
 Imports:
     checkmate,
     colourpicker,
@@ -44,18 +44,18 @@ Imports:
     shinyjs,
     shinyvalidate,
     stats,
-    teal.code (>= 0.3.0),
+    teal.code (>= 0.3.0.9009),
     teal.logger (>= 0.1.1),
-    teal.reporter (>= 0.1.1),
-    teal.transform (>= 0.2.0),
-    teal.widgets (>= 0.2.0),
+    teal.reporter (>= 0.1.1.9020),
+    teal.transform (>= 0.3.0.9009),
+    teal.widgets (>= 0.3.0.9010),
     tidyr
 Suggests:
     knitr,
     nestcolor (>= 0.1.0),
     rmarkdown,
     stringr,
-    teal.data (>= 0.2.0),
+    teal.data (>= 0.2.0.9007),
     tern (>= 0.7.10),
     testthat (>= 2.0),
     utils

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.goshawk 0.1.14.9021
+# teal.goshawk 0.1.15
 
 ### Enhancements
 


### PR DESCRIPTION
Releasing 0.1.15

Linking with:
https://github.com/insightsengineering/nestdevs-tasks/issues/25