### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     nestcolor (>= 0.1.0),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     stringr (>= 1.4.1),
     teal.data (>= 0.3.0.9018),
     tern (>= 0.7.10),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.