### PR TITLE
Fixing  `LOQFL_COMB` calculation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # teal.goshawk 0.1.15.9023
 
 * Removed `Show Warnings` modals from modules.
+* Fixed `LOQFL_COMB` calculation.
 
 ### Breaking Changes
 * Adapted all modules to use `teal_data` objects.

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -611,6 +611,7 @@ srv_g_correlationplot <- function(id,
     yloqfl <- reactive(paste0("LOQFL_", input$yaxis_param))
     xlabs <- reactive(paste0("LBSTRESC_", input$xaxis_param))
     ylabs <- reactive(paste0("LBSTRESC_", input$yaxis_param))
+
     # transpose data to plot
     plot_data_transpose <- reactive({
       teal::validate_inputs(iv_r())

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -687,24 +687,24 @@ srv_g_correlationplot <- function(id,
                 .data[[.(xloqfl())]] == "Y" & (
                   (grepl("<", .data[[.(xlabs())]]) & .data[[.(xvar())]] < as.numeric(gsub("[^0-9.-]", "", .data[[.(xlabs())]]))) |
                     (grepl(">", .data[[.(xlabs())]]) & .data[[.(xvar())]] > as.numeric(gsub("[^0-9.-]", "", .data[[.(xlabs())]])))
-                ), "Y", ifelse(.data[[.(xloqfl())]] == "Y", "N", as.character(.data[[.(xloqfl())]])
-                )),
-                y_temp = ifelse(
-                  .data[[.(yloqfl())]] == "Y" & (
-                    (grepl("<", .data[[.(ylabs())]]) & .data[[.(yvar())]] < as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]]))) |
-                      (grepl(">", .data[[.(ylabs())]]) & .data[[.(yvar())]] > as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]])))
-                  ), "Y", ifelse(.data[[.(yloqfl())]] == "Y", "N", as.character(.data[[.(yloqfl())]])
-                  )
-                )) %>%
-                  dplyr::mutate(LOQFL_COMB = dplyr::case_when(
-                    x_temp == "Y" | y_temp == "Y" ~ "Y",
-                    x_temp == "N" & y_temp == "N" ~ "N",
-                    x_temp == "N" & y_temp == "NA" ~ "N",
-                    x_temp == "NA" & y_temp == "N" ~ "N",
-                    x_temp == "NA" & y_temp == "NA" ~ "NA",
-                    TRUE ~ as.character(NA)
-                  ))%>%
-                  dplyr::select(-x_temp, -y_temp)
+                ), "Y", ifelse(.data[[.(xloqfl())]] == "Y", "N", as.character(.data[[.(xloqfl())]]))
+              ),
+              y_temp = ifelse(
+                .data[[.(yloqfl())]] == "Y" & (
+                  (grepl("<", .data[[.(ylabs())]]) & .data[[.(yvar())]] < as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]]))) |
+                    (grepl(">", .data[[.(ylabs())]]) & .data[[.(yvar())]] > as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]])))
+                ), "Y", ifelse(.data[[.(yloqfl())]] == "Y", "N", as.character(.data[[.(yloqfl())]]))
+              )
+            ) %>%
+            dplyr::mutate(LOQFL_COMB = dplyr::case_when(
+              x_temp == "Y" | y_temp == "Y" ~ "Y",
+              x_temp == "N" & y_temp == "N" ~ "N",
+              x_temp == "N" & y_temp == "NA" ~ "N",
+              x_temp == "NA" & y_temp == "N" ~ "N",
+              x_temp == "NA" & y_temp == "NA" ~ "NA",
+              TRUE ~ as.character(NA)
+            )) %>%
+            dplyr::select(-x_temp, -y_temp)
         })
       )
 

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -683,28 +683,32 @@ srv_g_correlationplot <- function(id,
           ANL_TRANSPOSED <- merge(ANL_TRANSPOSED1, ANL_TRANSPOSED2) # nolint
           ANL_TRANSPOSED <- ANL_TRANSPOSED %>%
             dplyr::mutate(
-              x_temp = ifelse(
+              xloqfl_temp = dplyr::case_when(
                 .data[[.(xloqfl())]] == "Y" & (
                   (grepl("<", .data[[.(xlabs())]]) & .data[[.(xvar())]] < as.numeric(gsub("[^0-9.-]", "", .data[[.(xlabs())]]))) |
                     (grepl(">", .data[[.(xlabs())]]) & .data[[.(xvar())]] > as.numeric(gsub("[^0-9.-]", "", .data[[.(xlabs())]])))
-                ), "Y", ifelse(.data[[.(xloqfl())]] == "Y", "N", as.character(.data[[.(xloqfl())]]))
+                ) ~ "Y",
+                .data[[.(xloqfl())]] == "Y" ~ "N",
+                TRUE ~ as.character(.data[[.(xloqfl())]])
               ),
-              y_temp = ifelse(
+              yloqfl_temp = dplyr::case_when(
                 .data[[.(yloqfl())]] == "Y" & (
                   (grepl("<", .data[[.(ylabs())]]) & .data[[.(yvar())]] < as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]]))) |
                     (grepl(">", .data[[.(ylabs())]]) & .data[[.(yvar())]] > as.numeric(gsub("[^0-9.-]", "", .data[[.(ylabs())]])))
-                ), "Y", ifelse(.data[[.(yloqfl())]] == "Y", "N", as.character(.data[[.(yloqfl())]]))
+                ) ~ "Y",
+                .data[[.(yloqfl())]] == "Y" ~ "N",
+                TRUE ~ as.character(.data[[.(yloqfl())]])
               )
             ) %>%
             dplyr::mutate(LOQFL_COMB = dplyr::case_when(
-              x_temp == "Y" | y_temp == "Y" ~ "Y",
-              x_temp == "N" & y_temp == "N" ~ "N",
-              x_temp == "N" & y_temp == "NA" ~ "N",
-              x_temp == "NA" & y_temp == "N" ~ "N",
-              x_temp == "NA" & y_temp == "NA" ~ "NA",
+              xloqfl_temp == "Y" | yloqfl_temp == "Y" ~ "Y",
+              xloqfl_temp == "N" & yloqfl_temp == "N" ~ "N",
+              xloqfl_temp == "N" & yloqfl_temp == "NA" ~ "N",
+              xloqfl_temp == "NA" & yloqfl_temp == "N" ~ "N",
+              xloqfl_temp == "NA" & yloqfl_temp == "NA" ~ "NA",
               TRUE ~ as.character(NA)
             )) %>%
-            dplyr::select(-x_temp, -y_temp)
+            dplyr::select(-xloqfl_temp, -yloqfl_temp)
         })
       )
 


### PR DESCRIPTION
This PR fixes the calculation of `LOQFL_COMB`:

To check this, access the `THEORY` app.

In the correlation plot, there are controls for Biomarker (PARAM) and Analysis Variable (AVAL, BASE, etc.) for each axis. For the LoQ legend to display "Y", one of the PARAM values must have LOQFL == "Y". Albumin does not have any LOQFL == "Y" values, and it is the PARAM that has been selected for both axes.

PR add calcaltion for `LOQFL_COMB` earlier  `LOQFL_COMB` is  "Y" when neither of those values is LOQFL == "Y" in the data.

For example, LOQFL_COMB is "Y" for BASE.ALT x AVAL.ALBUM at week 12 when neither is a LoQ value.


TODO: 

- [ ]  Fix ajax error on selecting different biomarker DT table throws ajax error