### PR TITLE
Revert update to add new teal.logger shiny input changes feature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Imports:
     shinyvalidate,
     stats,
     teal.code (>= 0.4.1.9009),
-    teal.logger (>= 0.2.0.9004),
+    teal.logger (>= 0.2.0),
     teal.reporter (>= 0.2.0),
     teal.widgets (>= 0.4.0)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,6 @@
 * Adapted all modules to use `teal_data` objects.
 
 ### Enhancements
-* Added `teal.logger` functionality for logging changes in shiny inputs in all modules.
 * Updated the documentation and vignettes to demonstrate method to pass `teal_data` object to `teal::init()`.
 
 ### Miscellaneous

--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -326,7 +326,7 @@ srv_g_boxplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -326,7 +326,6 @@ srv_g_boxplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -382,7 +382,6 @@ srv_g_correlationplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x_param <- teal.transform::resolve_delayed(module_args$xaxis_param, env)

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -382,7 +382,7 @@ srv_g_correlationplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x_param <- teal.transform::resolve_delayed(module_args$xaxis_param, env)

--- a/R/tm_g_gh_density_distribution_plot.R
+++ b/R/tm_g_gh_density_distribution_plot.R
@@ -268,7 +268,7 @@ srv_g_density_distribution_plot <- function(id, # nolint
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_density_distribution_plot.R
+++ b/R/tm_g_gh_density_distribution_plot.R
@@ -268,7 +268,6 @@ srv_g_density_distribution_plot <- function(id, # nolint
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -356,7 +356,6 @@ srv_lineplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     ns <- session$ns
 
     output$axis_selections <- renderUI({

--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -356,7 +356,7 @@ srv_lineplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     ns <- session$ns
 
     output$axis_selections <- renderUI({

--- a/R/tm_g_gh_scatterplot.R
+++ b/R/tm_g_gh_scatterplot.R
@@ -267,7 +267,7 @@ srv_g_scatterplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_scatterplot.R
+++ b/R/tm_g_gh_scatterplot.R
@@ -267,7 +267,6 @@ srv_g_scatterplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -376,7 +376,6 @@ srv_g_spaghettiplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -376,7 +376,7 @@ srv_g_spaghettiplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     output$axis_selections <- renderUI({
       env <- shiny::isolate(as.list(data()@env))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)

--- a/R/toggleable_slider.R
+++ b/R/toggleable_slider.R
@@ -142,7 +142,7 @@ toggle_slider_ui <- function(id,
 # is_dichotomous_slider `logical` whether it is a dichotomous slider or normal slider
 toggle_slider_server <- function(id, is_dichotomous_slider = TRUE) {
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     checkmate::assert_flag(is_dichotomous_slider)
     # model view controller: cur_state is the model, the sliderInput and numericInputs are two views/controllers
     # additionally, the module returns the cur_state, so it can be controlled from that end as well

--- a/R/toggleable_slider.R
+++ b/R/toggleable_slider.R
@@ -142,7 +142,6 @@ toggle_slider_ui <- function(id,
 # is_dichotomous_slider `logical` whether it is a dichotomous slider or normal slider
 toggle_slider_server <- function(id, is_dichotomous_slider = TRUE) {
   moduleServer(id, function(input, output, session) {
-
     checkmate::assert_flag(is_dichotomous_slider)
     # model view controller: cur_state is the model, the sliderInput and numericInputs are two views/controllers
     # additionally, the module returns the cur_state, so it can be controlled from that end as well

--- a/R/utils-arbitrary_lines.r
+++ b/R/utils-arbitrary_lines.r
@@ -48,7 +48,7 @@ ui_arbitrary_lines <- function(id, line_arb, line_arb_label, line_arb_color, tit
 #' @keywords internal
 srv_arbitrary_lines <- function(id) {
   moduleServer(id, function(input, output, session) {
-    teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
+
     comma_sep_to_values <- function(values, wrapper_fun = trimws) {
       vals <- strsplit(values, "\\s{0,},\\s{0,}")[[1]]
       suppressWarnings(wrapper_fun(vals))


### PR DESCRIPTION
As discussed, we will revert the changes to add shiny input changes for teal.goshawk for now so we can move forward with release.

Related to https://github.com/insightsengineering/teal.goshawk/issues/297