### PR TITLE
284 add callback for `DT::datable` to hide AJAX warnings

### DIFF
--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -510,8 +510,10 @@ srv_g_boxplot <- function(id,
 
       numeric_cols <- setdiff(names(dplyr::select_if(tbl, is.numeric)), "n")
 
-      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(tbl,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 4)
     })
 
@@ -578,8 +580,10 @@ srv_g_boxplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(df,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -510,7 +510,8 @@ srv_g_boxplot <- function(id,
 
       numeric_cols <- setdiff(names(dplyr::select_if(tbl, is.numeric)), "n")
 
-      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 4)
     })
 
@@ -577,7 +578,8 @@ srv_g_boxplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -879,7 +879,8 @@ srv_g_correlationplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -879,8 +879,10 @@ srv_g_correlationplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(df,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_density_distribution_plot.R
+++ b/R/tm_g_gh_density_distribution_plot.R
@@ -410,8 +410,10 @@ srv_g_density_distribution_plot <- function(id, # nolint
       tbl <- create_table()[["tbl"]]
       numeric_cols <- names(dplyr::select_if(tbl, is.numeric))
 
-      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(tbl,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 2)
     })
 

--- a/R/tm_g_gh_density_distribution_plot.R
+++ b/R/tm_g_gh_density_distribution_plot.R
@@ -410,7 +410,8 @@ srv_g_density_distribution_plot <- function(id, # nolint
       tbl <- create_table()[["tbl"]]
       numeric_cols <- names(dplyr::select_if(tbl, is.numeric))
 
-      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(tbl, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 2)
     })
 

--- a/R/tm_g_gh_scatterplot.R
+++ b/R/tm_g_gh_scatterplot.R
@@ -429,8 +429,10 @@ srv_g_scatterplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(df,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_scatterplot.R
+++ b/R/tm_g_gh_scatterplot.R
@@ -429,7 +429,8 @@ srv_g_scatterplot <- function(id,
 
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -578,7 +578,8 @@ srv_g_spaghettiplot <- function(id,
       df <- df[order(df$PARAMCD, df[[trt_group]], df$USUBJID, df[[xvar]]), ]
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE)) %>%
+      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
+                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
         DT::formatRound(numeric_cols, 4)
     })
 

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -578,8 +578,10 @@ srv_g_spaghettiplot <- function(id,
       df <- df[order(df$PARAMCD, df[[trt_group]], df$USUBJID, df[[xvar]]), ]
       numeric_cols <- names(dplyr::select_if(df, is.numeric))
 
-      DT::datatable(df, rownames = FALSE, options = list(scrollX = TRUE),
-                    callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")) %>%
+      DT::datatable(df,
+        rownames = FALSE, options = list(scrollX = TRUE),
+        callback = DT::JS("$.fn.dataTable.ext.errMode = 'none';")
+      ) %>%
         DT::formatRound(numeric_cols, 4)
     })
 


### PR DESCRIPTION
Solution for #284 that do not pop-up AJAX warnings from JavaScript DataTable when computations happens too often and rendering is behind the state of the data.

This adds a callback behavior for `DT::datatable`. We also tested the global setup of this behavior in teal but we were unable to include javascript in a way that it is executed after the object is created. Other modules in other packages don't really need that as they have better reactivity handling. The modules in teal.goshawk have very much reactivitiy and could be refactored one day but that's a bigger project.