### PR TITLE
`teal.data::datanames()` is deprecated in favor of dot-prefix and `names()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,8 @@ Depends:
     goshawk (>= 0.1.18),
     R (>= 3.6),
     shiny (>= 1.6.0),
-    teal (>= 0.15.2),
-    teal.transform (>= 0.5.0)
+    teal (>= 0.15.2.9079),
+    teal.transform (>= 0.5.0.9015)
 Imports:
     checkmate (>= 2.1.0),
     colourpicker,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     shinyjs,
     shinyvalidate,
     stats,
-    teal.code (>= 0.5.0),
+    teal.code (>= 0.5.0.9012),
     teal.logger (>= 0.2.0.9011),
     teal.reporter (>= 0.2.0),
     teal.widgets (>= 0.4.0)
@@ -58,7 +58,7 @@ Suggests:
     rvest (>= 1.0.0),
     shinytest2,
     stringr (>= 1.4.1),
-    teal.data (>= 0.5.0),
+    teal.data (>= 0.6.0.9015),
     tern (>= 0.7.10),
     testthat (>= 3.0.4),
     utils

--- a/R/tm_g_gh_boxplot.R
+++ b/R/tm_g_gh_boxplot.R
@@ -54,10 +54,10 @@
 #'   library(stringr)
 #'
 #'   # use non-exported function from goshawk
-#'   h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+#'   .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
@@ -65,7 +65,7 @@
 #'   set.seed(1)
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(
 #'       AVISITCD = case_when(
@@ -86,9 +86,9 @@
 #'         ARMCD == "ARM B" ~ 2,
 #'         ARMCD == "ARM A" ~ 3
 #'       ),
-#'       ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+#'       ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
 #'       ARM = factor(ARM) %>% reorder(TRTORD),
-#'       ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+#'       ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
 #'       ACTARM = factor(ACTARM) %>% reorder(TRTORD),
 #'       ANRLO = 50,
 #'       ANRHI = 75
@@ -105,20 +105,17 @@
 #'     )) %>%
 #'     ungroup()
 #'
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-#'   attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+#'   attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 #'   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
 #'   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 #'
 #'   # add LLOQ and ULOQ variables
-#'   ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+#'   ALB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
 #'   ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#'
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -308,7 +305,7 @@ srv_g_boxplot <- function(id,
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_y <- teal.transform::resolve_delayed(module_args$yaxis_var, env)
       resolved_param <- teal.transform::resolve_delayed(module_args$param, env)
@@ -508,7 +505,7 @@ srv_g_boxplot <- function(id,
 
     joined_qenvs <- reactive({
       req(create_plot(), create_table())
-      teal.code::join(create_plot(), create_table())
+      c(create_plot(), create_table())
     })
 
     code <- reactive(teal.code::get_code(joined_qenvs()))

--- a/R/tm_g_gh_correlationplot.R
+++ b/R/tm_g_gh_correlationplot.R
@@ -57,22 +57,22 @@
 #'   library(stringr)
 #'
 #'   # use non-exported function from goshawk
-#'   h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+#'   .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
 #'   )
-#'   color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")
+#'   .color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")
 #'   # assign LOQ flag symbols: circles for "N" and triangles for "Y", squares for "NA"
-#'   shape_manual <- c("N" = 1, "Y" = 2, "NA" = 0)
+#'   .shape_manual <- c("N" = 1, "Y" = 2, "NA" = 0)
 #'
 #'   set.seed(1)
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(AVISITCD = case_when(
 #'       AVISIT == "SCREENING" ~ "SCR",
@@ -102,7 +102,7 @@
 #'         ifelse(grepl("A", ARMCD), 3, NA)
 #'       )
 #'     )) %>%
-#'     mutate(ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))])) %>%
+#'     mutate(ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))])) %>%
 #'     mutate(ARM = factor(ARM) %>%
 #'       reorder(TRTORD)) %>%
 #'     mutate(
@@ -130,19 +130,16 @@
 #'       paste(">", round(runif(1, min = 70, max = 75))), LBSTRESC
 #'     )) %>%
 #'     ungroup()
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
 #'   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 #'   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
 #'
 #'   # add LLOQ and ULOQ variables
-#'   ADLB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+#'   ADLB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
 #'   ADLB <- left_join(ADLB, ADLB_LOQS, by = "PARAM")
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#'
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -374,7 +371,7 @@ srv_g_correlationplot <- function(id,
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x_param <- teal.transform::resolve_delayed(module_args$xaxis_param, env)
       resolved_x_var <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_y_param <- teal.transform::resolve_delayed(module_args$yaxis_param, env)

--- a/R/tm_g_gh_density_distribution_plot.R
+++ b/R/tm_g_gh_density_distribution_plot.R
@@ -40,14 +40,14 @@
 #'   library(stringr)
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
 #'   )
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(
 #'       AVISITCD = case_when(
@@ -68,19 +68,17 @@
 #'         ARMCD == "ARM B" ~ 2,
 #'         ARMCD == "ARM A" ~ 3
 #'       ),
-#'       ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+#'       ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
 #'       ARM = factor(ARM) %>% reorder(TRTORD),
-#'       ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+#'       ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
 #'       ACTARM = factor(ACTARM) %>% reorder(TRTORD)
 #'     )
 #'
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-#'   attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+#'   attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -256,7 +254,7 @@ srv_g_density_distribution_plot <- function(id, # nolint
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_param <- teal.transform::resolve_delayed(module_args$param, env)
       resolved_trt <- teal.transform::resolve_delayed(module_args$trt_group, env)
@@ -416,7 +414,7 @@ srv_g_density_distribution_plot <- function(id, # nolint
 
     joined_qenvs <- reactive({
       req(create_plot(), create_table())
-      teal.code::join(create_plot(), create_table())
+      c(create_plot(), create_table())
     })
 
     code <- reactive(teal.code::get_code(joined_qenvs()))

--- a/R/tm_g_gh_lineplot.R
+++ b/R/tm_g_gh_lineplot.R
@@ -60,7 +60,7 @@
 #'   library(nestcolor)
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
@@ -68,7 +68,7 @@
 #'
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(
 #'       AVISITCD = case_when(
@@ -89,18 +89,16 @@
 #'         ARMCD == "ARM B" ~ 2,
 #'         ARMCD == "ARM A" ~ 3
 #'       ),
-#'       ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+#'       ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
 #'       ARM = factor(ARM) %>% reorder(TRTORD),
-#'       ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+#'       ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
 #'       ACTARM = factor(ACTARM) %>% reorder(TRTORD)
 #'     )
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-#'   attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+#'   attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -349,7 +347,7 @@ srv_lineplot <- function(id,
     ns <- session$ns
 
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_y <- teal.transform::resolve_delayed(module_args$yaxis_var, env)
       resolved_param <- teal.transform::resolve_delayed(module_args$param, env)

--- a/R/tm_g_gh_scatterplot.R
+++ b/R/tm_g_gh_scatterplot.R
@@ -45,7 +45,7 @@
 #'   library(stringr)
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
@@ -53,7 +53,7 @@
 #'
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(
 #'       AVISITCD = case_when(
@@ -74,18 +74,16 @@
 #'         ARMCD == "ARM B" ~ 2,
 #'         ARMCD == "ARM A" ~ 3
 #'       ),
-#'       ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+#'       ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
 #'       ARM = factor(ARM) %>% reorder(TRTORD),
-#'       ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+#'       ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
 #'       ACTARM = factor(ACTARM) %>% reorder(TRTORD)
 #'     )
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-#'   attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+#'   attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #'
 #' app <- init(
@@ -257,7 +255,7 @@ srv_g_scatterplot <- function(id,
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_y <- teal.transform::resolve_delayed(module_args$yaxis_var, env)
       resolved_param <- teal.transform::resolve_delayed(module_args$param, env)

--- a/R/tm_g_gh_spaghettiplot.R
+++ b/R/tm_g_gh_spaghettiplot.R
@@ -63,10 +63,10 @@
 #'   library(stringr)
 #'
 #'   # use non-exported function from goshawk
-#'   h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+#'   .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 #'
 #'   # original ARM value = dose value
-#'   arm_mapping <- list(
+#'   .arm_mapping <- list(
 #'     "A: Drug X" = "150mg QD",
 #'     "B: Placebo" = "Placebo",
 #'     "C: Combination" = "Combination"
@@ -74,7 +74,7 @@
 #'   set.seed(1)
 #'   ADSL <- rADSL
 #'   ADLB <- rADLB
-#'   var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+#'   .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
 #'   ADLB <- ADLB %>%
 #'     mutate(
 #'       AVISITCD = case_when(
@@ -95,9 +95,9 @@
 #'         ARMCD == "ARM B" ~ 2,
 #'         ARMCD == "ARM A" ~ 3
 #'       ),
-#'       ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+#'       ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
 #'       ARM = factor(ARM) %>% reorder(TRTORD),
-#'       ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+#'       ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
 #'       ACTARM = factor(ACTARM) %>% reorder(TRTORD),
 #'       ANRLO = 30,
 #'       ANRHI = 75
@@ -111,19 +111,17 @@
 #'       paste(">", round(runif(1, min = 70, max = 75))), LBSTRESC
 #'     )) %>%
 #'     ungroup()
-#'   attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-#'   attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+#'   attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+#'   attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 #'   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
 #'   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 #'
 #'   # add LLOQ and ULOQ variables
-#'   ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+#'   ALB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
 #'   ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
 #' })
 #'
-#' datanames <- c("ADSL", "ADLB")
-#' datanames(data) <- datanames
-#' join_keys(data) <- default_cdisc_join_keys[datanames]
+#' join_keys(data) <- default_cdisc_join_keys[names(data)]
 #'
 #' app <- init(
 #'   data = data,
@@ -367,7 +365,7 @@ srv_g_spaghettiplot <- function(id,
   moduleServer(id, function(input, output, session) {
     teal.logger::log_shiny_input_changes(input, namespace = "teal.goshawk")
     output$axis_selections <- renderUI({
-      env <- shiny::isolate(as.list(data()@env))
+      env <- shiny::isolate(as.list(data()))
       resolved_x <- teal.transform::resolve_delayed(module_args$xaxis_var, env)
       resolved_y <- teal.transform::resolve_delayed(module_args$yaxis_var, env)
       resolved_param <- teal.transform::resolve_delayed(module_args$param, env)

--- a/R/utils-arbitrary_lines.r
+++ b/R/utils-arbitrary_lines.r
@@ -48,7 +48,6 @@ ui_arbitrary_lines <- function(id, line_arb, line_arb_label, line_arb_color, tit
 #' @keywords internal
 srv_arbitrary_lines <- function(id) {
   moduleServer(id, function(input, output, session) {
-
     comma_sep_to_values <- function(values, wrapper_fun = trimws) {
       vals <- strsplit(values, "\\s{0,},\\s{0,}")[[1]]
       suppressWarnings(wrapper_fun(vals))

--- a/R/utils-templ_ui.r
+++ b/R/utils-templ_ui.r
@@ -33,7 +33,6 @@ templ_ui_params_vars <- function(ns,
                                  # trt_group
                                  trt_choices = NULL,
                                  trt_selected = NULL,
-
                                  multiple = FALSE) {
   if (is.null(xparam_choices) && !is.null(xchoices) && !is.null(yparam_choices)) {
     # otherwise, xchoices will appear first without any biomarker to select and this looks odd in the UI

--- a/man/tm_g_gh_boxplot.Rd
+++ b/man/tm_g_gh_boxplot.Rd
@@ -113,10 +113,10 @@ data <- within(data, {
   library(stringr)
 
   # use non-exported function from goshawk
-  h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+  .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
@@ -124,7 +124,7 @@ data <- within(data, {
   set.seed(1)
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(
       AVISITCD = case_when(
@@ -145,9 +145,9 @@ data <- within(data, {
         ARMCD == "ARM B" ~ 2,
         ARMCD == "ARM A" ~ 3
       ),
-      ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+      ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
       ARM = factor(ARM) \%>\% reorder(TRTORD),
-      ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+      ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
       ACTARM = factor(ACTARM) \%>\% reorder(TRTORD),
       ANRLO = 50,
       ANRHI = 75
@@ -164,20 +164,17 @@ data <- within(data, {
     )) \%>\%
     ungroup()
 
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-  attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+  attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 
   # add LLOQ and ULOQ variables
-  ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+  ALB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
   ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_gh_correlationplot.Rd
+++ b/man/tm_g_gh_correlationplot.Rd
@@ -133,22 +133,22 @@ data <- within(data, {
   library(stringr)
 
   # use non-exported function from goshawk
-  h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+  .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
   )
-  color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")
+  .color_manual <- c("150mg QD" = "#000000", "Placebo" = "#3498DB", "Combination" = "#E74C3C")
   # assign LOQ flag symbols: circles for "N" and triangles for "Y", squares for "NA"
-  shape_manual <- c("N" = 1, "Y" = 2, "NA" = 0)
+  .shape_manual <- c("N" = 1, "Y" = 2, "NA" = 0)
 
   set.seed(1)
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(AVISITCD = case_when(
       AVISIT == "SCREENING" ~ "SCR",
@@ -178,7 +178,7 @@ data <- within(data, {
         ifelse(grepl("A", ARMCD), 3, NA)
       )
     )) \%>\%
-    mutate(ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))])) \%>\%
+    mutate(ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))])) \%>\%
     mutate(ARM = factor(ARM) \%>\%
       reorder(TRTORD)) \%>\%
     mutate(
@@ -206,19 +206,16 @@ data <- within(data, {
       paste(">", round(runif(1, min = 70, max = 75))), LBSTRESC
     )) \%>\%
     ungroup()
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
 
   # add LLOQ and ULOQ variables
-  ADLB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+  ADLB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
   ADLB <- left_join(ADLB, ADLB_LOQS, by = "PARAM")
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_gh_density_distribution_plot.Rd
+++ b/man/tm_g_gh_density_distribution_plot.Rd
@@ -89,14 +89,14 @@ data <- within(data, {
   library(stringr)
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
   )
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(
       AVISITCD = case_when(
@@ -117,19 +117,17 @@ data <- within(data, {
         ARMCD == "ARM B" ~ 2,
         ARMCD == "ARM A" ~ 3
       ),
-      ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+      ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
       ARM = factor(ARM) \%>\% reorder(TRTORD),
-      ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+      ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
       ACTARM = factor(ACTARM) \%>\% reorder(TRTORD)
     )
 
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-  attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+  attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_gh_lineplot.Rd
+++ b/man/tm_g_gh_lineplot.Rd
@@ -132,7 +132,7 @@ data <- within(data, {
   library(nestcolor)
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
@@ -140,7 +140,7 @@ data <- within(data, {
 
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(
       AVISITCD = case_when(
@@ -161,18 +161,16 @@ data <- within(data, {
         ARMCD == "ARM B" ~ 2,
         ARMCD == "ARM A" ~ 3
       ),
-      ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+      ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
       ARM = factor(ARM) \%>\% reorder(TRTORD),
-      ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+      ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
       ACTARM = factor(ACTARM) \%>\% reorder(TRTORD)
     )
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-  attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+  attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/man/tm_g_gh_scatterplot.Rd
+++ b/man/tm_g_gh_scatterplot.Rd
@@ -93,7 +93,7 @@ data <- within(data, {
   library(stringr)
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
@@ -101,7 +101,7 @@ data <- within(data, {
 
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(
       AVISITCD = case_when(
@@ -122,18 +122,16 @@ data <- within(data, {
         ARMCD == "ARM B" ~ 2,
         ARMCD == "ARM A" ~ 3
       ),
-      ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+      ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
       ARM = factor(ARM) \%>\% reorder(TRTORD),
-      ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+      ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
       ACTARM = factor(ACTARM) \%>\% reorder(TRTORD)
     )
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-  attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+  attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 
 app <- init(

--- a/man/tm_g_gh_spaghettiplot.Rd
+++ b/man/tm_g_gh_spaghettiplot.Rd
@@ -134,10 +134,10 @@ data <- within(data, {
   library(stringr)
 
   # use non-exported function from goshawk
-  h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+  .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 
   # original ARM value = dose value
-  arm_mapping <- list(
+  .arm_mapping <- list(
     "A: Drug X" = "150mg QD",
     "B: Placebo" = "Placebo",
     "C: Combination" = "Combination"
@@ -145,7 +145,7 @@ data <- within(data, {
   set.seed(1)
   ADSL <- rADSL
   ADLB <- rADLB
-  var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+  .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
   ADLB <- ADLB \%>\%
     mutate(
       AVISITCD = case_when(
@@ -166,9 +166,9 @@ data <- within(data, {
         ARMCD == "ARM B" ~ 2,
         ARMCD == "ARM A" ~ 3
       ),
-      ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+      ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
       ARM = factor(ARM) \%>\% reorder(TRTORD),
-      ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+      ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
       ACTARM = factor(ACTARM) \%>\% reorder(TRTORD),
       ANRLO = 30,
       ANRHI = 75
@@ -182,19 +182,17 @@ data <- within(data, {
       paste(">", round(runif(1, min = 70, max = 75))), LBSTRESC
     )) \%>\%
     ungroup()
-  attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-  attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+  attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+  attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
   attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
   attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 
   # add LLOQ and ULOQ variables
-  ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+  ALB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
   ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- init(
   data = data,

--- a/tests/testthat/helper-module-utils.R
+++ b/tests/testthat/helper-module-utils.R
@@ -64,7 +64,7 @@ get_test_data <- function() {
     attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 
     # add LLOQ and ULOQ variables
-    ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
+    ALB_LOQS <- .h_identify_loq_values(ADLB, "LOQFL")
     ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
   })
   join_keys(data) <- default_cdisc_join_keys[names(data)]

--- a/tests/testthat/helper-module-utils.R
+++ b/tests/testthat/helper-module-utils.R
@@ -7,10 +7,10 @@ get_test_data <- function() {
     library(stringr)
 
     # use non-exported function from goshawk
-    h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
+    .h_identify_loq_values <- getFromNamespace("h_identify_loq_values", "goshawk")
 
     # original ARM value = dose value
-    arm_mapping <- list(
+    .arm_mapping <- list(
       "A: Drug X" = "150mg QD",
       "B: Placebo" = "Placebo",
       "C: Combination" = "Combination"
@@ -18,7 +18,7 @@ get_test_data <- function() {
     set.seed(1)
     ADSL <- rADSL
     ADLB <- rADLB
-    var_labels <- lapply(ADLB, function(x) attributes(x)$label)
+    .var_labels <- lapply(ADLB, function(x) attributes(x)$label)
     ADLB <- ADLB %>%
       mutate(
         AVISITCD = case_when(
@@ -39,9 +39,9 @@ get_test_data <- function() {
           ARMCD == "ARM B" ~ 2,
           ARMCD == "ARM A" ~ 3
         ),
-        ARM = as.character(arm_mapping[match(ARM, names(arm_mapping))]),
+        ARM = as.character(.arm_mapping[match(ARM, names(.arm_mapping))]),
         ARM = factor(ARM) %>% reorder(TRTORD),
-        ACTARM = as.character(arm_mapping[match(ACTARM, names(arm_mapping))]),
+        ACTARM = as.character(.arm_mapping[match(ACTARM, names(.arm_mapping))]),
         ACTARM = factor(ACTARM) %>% reorder(TRTORD),
         ANRLO = 50,
         ANRHI = 75
@@ -58,8 +58,8 @@ get_test_data <- function() {
       )) %>%
       ungroup()
 
-    attr(ADLB[["ARM"]], "label") <- var_labels[["ARM"]]
-    attr(ADLB[["ACTARM"]], "label") <- var_labels[["ACTARM"]]
+    attr(ADLB[["ARM"]], "label") <- .var_labels[["ARM"]]
+    attr(ADLB[["ACTARM"]], "label") <- .var_labels[["ACTARM"]]
     attr(ADLB[["ANRLO"]], "label") <- "Analysis Normal Range Lower Limit"
     attr(ADLB[["ANRHI"]], "label") <- "Analysis Normal Range Upper Limit"
 
@@ -67,9 +67,7 @@ get_test_data <- function() {
     ALB_LOQS <- h_identify_loq_values(ADLB, "LOQFL")
     ADLB <- left_join(ADLB, ALB_LOQS, by = "PARAM")
   })
-  datanames <- c("ADSL", "ADLB")
-  datanames(data) <- datanames
-  join_keys(data) <- default_cdisc_join_keys[datanames]
+  join_keys(data) <- default_cdisc_join_keys[names(data)]
   data
 }
 # nolint end

--- a/vignettes/teal-goshawk.Rmd
+++ b/vignettes/teal-goshawk.Rmd
@@ -73,9 +73,7 @@ data <- within(data, {
     )
 })
 
-datanames <- c("ADSL", "ADLB")
-datanames(data)<- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[names(data)]
 
 app <- teal::init(
   data = data,


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/teal.data/issues/333

Blocked by:

- https://github.com/insightsengineering/teal.code/pull/218
- https://github.com/insightsengineering/teal.data/pull/347
- https://github.com/insightsengineering/teal/pull/1402