### PR TITLE
remove the click event in unit test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Suggests:
     testthat (>= 3.2.0),
     utils
 Remotes:
-    insightsengineering/goshawk
+    insightsengineering/goshawk,
     insightsengineering/teal.widgets
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,6 +66,7 @@ Remotes:
     insightsengineering/goshawk,
     insightsengineering/teal.widgets,
     insightsengineering/teal.transform,
+    insightsengineering/teal.reporter,
     insightsengineering/teal
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,6 +64,7 @@ Suggests:
     utils
 Remotes:
     insightsengineering/teal.widgets
+    insightsengineering/goshawk
 VignetteBuilder:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ Suggests:
 Remotes:
     insightsengineering/goshawk,
     insightsengineering/teal.widgets,
+    insightsengineering/teal.tranform,
     insightsengineering/teal
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,8 +63,8 @@ Suggests:
     testthat (>= 3.2.0),
     utils
 Remotes:
-    insightsengineering/teal.widgets
     insightsengineering/goshawk
+    insightsengineering/teal.widgets
 VignetteBuilder:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,8 @@ Suggests:
     utils
 Remotes:
     insightsengineering/goshawk,
-    insightsengineering/teal.widgets
+    insightsengineering/teal.widgets,
+    insightsengineering/teal
 VignetteBuilder:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,8 @@ Suggests:
     tern (>= 0.9.7),
     testthat (>= 3.2.0),
     utils
+Remotes:
+    insightsengineering/teal.widgets
 VignetteBuilder:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
 Remotes:
     insightsengineering/goshawk,
     insightsengineering/teal.widgets,
-    insightsengineering/teal.tranform,
+    insightsengineering/teal.transform,
     insightsengineering/teal
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,8 +67,6 @@ Remotes:
 VignetteBuilder:
     knitr,
     rmarkdown
-Remotes:
-    insightsengineering/goshawk
 Config/Needs/verdepcheck: insightsengineering/goshawk, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.transform, mllg/checkmate,

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -19,6 +19,8 @@ app_driver <- init_teal_app_driver(
   )
 )
 
+app_driver$wait_for_idle()
+
 testthat::test_that("toggle_slider_module: widgets are initialized with proper values", {
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -20,7 +20,6 @@ app_driver <- init_teal_app_driver(
 )
 
 testthat::test_that("toggle_slider_module: widgets are initialized with proper values", {
-  app_driver$click(selector = ".well .panel-group > div:first-of-type > .panel > .panel-heading")
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)
 })

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -38,7 +38,8 @@ app_driver <- function() {
       hline_arb_label = c("default_hori_A", "default_hori_B"),
       hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
       hline_vars_colors = c("pink", "brown", "purple", "black"),
-    )
+    ),
+    timeout = 20000
   )
   driver
 }

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -1,33 +1,57 @@
-app_driver <- init_teal_app_driver(
-  data = get_test_data(),
-  modules = tm_g_gh_boxplot(
-    label = "Box Plot",
-    dataname = "ADLB",
-    param_var = "PARAMCD",
-    param = choices_selected(c("ALT", "CRP", "IGA"), "ALT"),
-    yaxis_var = choices_selected(c("AVAL", "BASE", "CHG"), "AVAL"),
-    xaxis_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "STUDYID"), "ARM"),
-    facet_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "SEX"), "AVISITCD"),
-    trt_group = choices_selected(c("ARM", "ACTARM"), "ARM"),
-    loq_legend = TRUE,
-    rotate_xlab = FALSE,
-    hline_arb = c(60, 55),
-    hline_arb_color = c("grey", "red"),
-    hline_arb_label = c("default_hori_A", "default_hori_B"),
-    hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
-    hline_vars_colors = c("pink", "brown", "purple", "black"),
-  )
-)
+# app_driver <- init_teal_app_driver(
+#   data = get_test_data(),
+#   modules = tm_g_gh_boxplot(
+#     label = "Box Plot",
+#     dataname = "ADLB",
+#     param_var = "PARAMCD",
+#     param = choices_selected(c("ALT", "CRP", "IGA"), "ALT"),
+#     yaxis_var = choices_selected(c("AVAL", "BASE", "CHG"), "AVAL"),
+#     xaxis_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "STUDYID"), "ARM"),
+#     facet_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "SEX"), "AVISITCD"),
+#     trt_group = choices_selected(c("ARM", "ACTARM"), "ARM"),
+#     loq_legend = TRUE,
+#     rotate_xlab = FALSE,
+#     hline_arb = c(60, 55),
+#     hline_arb_color = c("grey", "red"),
+#     hline_arb_label = c("default_hori_A", "default_hori_B"),
+#     hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
+#     hline_vars_colors = c("pink", "brown", "purple", "black"),
+#   )
+# )
 
-app_driver$wait_for_idle()
+app_driver <- function() {
+  driver <- init_teal_app_driver(
+    data = get_test_data(),
+    modules = tm_g_gh_boxplot(
+      label = "Box Plot",
+      dataname = "ADLB",
+      param_var = "PARAMCD",
+      param = choices_selected(c("ALT", "CRP", "IGA"), "ALT"),
+      yaxis_var = choices_selected(c("AVAL", "BASE", "CHG"), "AVAL"),
+      xaxis_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "STUDYID"), "ARM"),
+      facet_var = choices_selected(c("ACTARM", "ARM", "AVISITCD", "SEX"), "AVISITCD"),
+      trt_group = choices_selected(c("ARM", "ACTARM"), "ARM"),
+      loq_legend = TRUE,
+      rotate_xlab = FALSE,
+      hline_arb = c(60, 55),
+      hline_arb_color = c("grey", "red"),
+      hline_arb_label = c("default_hori_A", "default_hori_B"),
+      hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
+      hline_vars_colors = c("pink", "brown", "purple", "black"),
+    )
+  )
+  driver
+}
 
 testthat::test_that("toggle_slider_module: widgets are initialized with proper values", {
+  app_driver <- app_driver()
   app_driver$wait_for_idle()
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)
 })
 
 testthat::test_that("toggle_slider_module: changing the sliderInput sets proper numericInput values", {
+  app_driver <- app_driver()
   app_driver$wait_for_idle()
   set_slider_values(app_driver, c(1, 50))
   check_widgets_with_value(
@@ -40,6 +64,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   within the sliderInput range, sets proper sliderInput values",
   {
+    app_driver <- app_driver()
     app_driver$wait_for_idle()
     initial_range <- list(min = 0, max = 55)
     new_value <- c(10, 40)
@@ -60,6 +85,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   outside the sliderInput range, sets proper sliderInput values and range",
   {
+    app_driver <- app_driver()
     app_driver$wait_for_idle()
     new_range <- c(-5, 60)
     set_numeric_input_low(app_driver, new_range[1])
@@ -79,6 +105,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   within the rage, sets back the sliderInput range to initial range",
   {
+    app_driver <- app_driver()
     app_driver$wait_for_idle()
     initial_range <- list(min = 0, max = 55)
     new_value <- c(11, 30)
@@ -99,6 +126,7 @@ testthat::test_that(
   "toggle_slider_module: changing dependant widgets outside
 sets proper sliderInput and numericInput values",
   {
+    app_driver <- app_driver()
     app_driver$wait_for_idle()
     app_driver$set_active_module_input("xaxis_param", "CRP")
     new_range <- c(5, 13)

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -22,11 +22,13 @@ app_driver <- init_teal_app_driver(
 app_driver$wait_for_idle()
 
 testthat::test_that("toggle_slider_module: widgets are initialized with proper values", {
+  app_driver$wait_for_idle()
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)
 })
 
 testthat::test_that("toggle_slider_module: changing the sliderInput sets proper numericInput values", {
+  app_driver$wait_for_idle()
   set_slider_values(app_driver, c(1, 50))
   check_widgets_with_value(
     app_driver,
@@ -38,6 +40,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   within the sliderInput range, sets proper sliderInput values",
   {
+    app_driver$wait_for_idle()
     initial_range <- list(min = 0, max = 55)
     new_value <- c(10, 40)
     set_numeric_input_low(app_driver, new_value[1])
@@ -57,6 +60,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   outside the sliderInput range, sets proper sliderInput values and range",
   {
+    app_driver$wait_for_idle()
     new_range <- c(-5, 60)
     set_numeric_input_low(app_driver, new_range[1])
     set_numeric_input_high(app_driver, new_range[2])
@@ -75,6 +79,7 @@ testthat::test_that(
   "toggle_slider_module: changing the numericInputs
   within the rage, sets back the sliderInput range to initial range",
   {
+    app_driver$wait_for_idle()
     initial_range <- list(min = 0, max = 55)
     new_value <- c(11, 30)
     set_numeric_input_low(app_driver, new_value[1])
@@ -94,6 +99,7 @@ testthat::test_that(
   "toggle_slider_module: changing dependant widgets outside
 sets proper sliderInput and numericInput values",
   {
+    app_driver$wait_for_idle()
     app_driver$set_active_module_input("xaxis_param", "CRP")
     new_range <- c(5, 13)
     check_widgets_with_value(

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -48,6 +48,7 @@ testthat::test_that("toggle_slider_module: widgets are initialized with proper v
   app_driver$wait_for_idle()
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)
+  app_driver$stop()
 })
 
 testthat::test_that("toggle_slider_module: changing the sliderInput sets proper numericInput values", {
@@ -58,6 +59,7 @@ testthat::test_that("toggle_slider_module: changing the sliderInput sets proper 
     app_driver,
     list(min = 0, max = 55, value = c(1, 50))
   )
+  app_driver$stop()
 })
 
 testthat::test_that(
@@ -78,6 +80,7 @@ testthat::test_that(
         value = new_value
       )
     )
+    app_driver$stop()
   }
 )
 
@@ -98,6 +101,7 @@ testthat::test_that(
         value = c(new_range[1], new_range[2])
       )
     )
+    app_driver$stop()
   }
 )
 
@@ -119,6 +123,7 @@ testthat::test_that(
         value = c(new_value[1], new_value[2])
       )
     )
+    app_driver$stop()
   }
 )
 

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -39,7 +39,7 @@ app_driver <- function() {
       hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
       hline_vars_colors = c("pink", "brown", "purple", "black"),
     ),
-    timeout = 20000
+    load_timeout = 20000
   )
   driver
 }


### PR DESCRIPTION
Fixes https://github.com/insightsengineering/coredev-tasks/issues/626

I'm removing the click event because: 
1. The css is no longer valid with the new design. 
2. With the new design, the accordion is expanded by default.


