### PR TITLE
skipping test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Depends:
     goshawk (>= 0.1.19),
     R (>= 3.6),
     shiny (>= 1.6.0),
-    teal (>= 0.16.0),
+    teal (>= 0.16.0.9003),
     teal.transform (>= 0.6.0)
 Imports:
     checkmate (>= 2.1.0),
@@ -49,8 +49,8 @@ Imports:
     stats,
     teal.code (>= 0.6.1),
     teal.logger (>= 0.3.2),
-    teal.reporter (>= 0.4.0),
-    teal.widgets (>= 0.4.3)
+    teal.reporter (>= 0.4.0.9004),
+    teal.widgets (>= 0.4.3.9001)
 Suggests:
     knitr (>= 1.42),
     nestcolor (>= 0.1.0),
@@ -66,7 +66,10 @@ VignetteBuilder:
     knitr,
     rmarkdown
 Remotes:
-    insightsengineering/goshawk
+    insightsengineering/goshawk,
+    insightsengineering/teal.widgets,
+    insightsengineering/teal.reporter,
+    insightsengineering/teal
 Config/Needs/verdepcheck: insightsengineering/goshawk, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.transform, mllg/checkmate,

--- a/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_gh_boxplot.R
@@ -20,6 +20,7 @@ app_driver <- init_teal_app_driver(
 )
 
 testthat::test_that("toggle_slider_module: widgets are initialized with proper values", {
+  testthat::skip("chromium")
   app_driver$click(selector = ".well .panel-group > div:first-of-type > .panel > .panel-heading")
   init_values <- list(min = 0, max = 55, value = c(0, 55))
   check_widgets_with_value(app_driver, init_values)


### PR DESCRIPTION
Fixes https://github.com/insightsengineering/coredev-tasks/issues/626

We're skipping any test that has interaction with UI element for now.
This is similar to what we did with https://github.com/insightsengineering/teal.modules.general/pull/869.


