### PR TITLE
Bump version of shiny to support `bslib` and align with `teal`'s min `shiny` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ BugReports: https://github.com/insightsengineering/teal.goshawk/issues
 Depends:
     goshawk (>= 0.1.19),
     R (>= 3.6),
-    shiny (>= 1.6.0),
+    shiny (>= 1.8.1),
     teal (>= 0.16.0.9003),
     teal.transform (>= 0.6.0)
 Imports:


### PR DESCRIPTION
Bump shiny version as per the discussion https://github.com/insightsengineering/teal.widgets/pull/312#discussion_r2250985703