### PR TITLE
chore: bump teal.code dependency to 0.7.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Imports:
     shinyjs (>= 2.1.0),
     shinyvalidate (>= 0.1.3),
     stats,
-    teal.code (>= 0.6.1),
+    teal.code (>= 0.7.0),
     teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0.9005),
     teal.widgets (>= 0.4.3.9001)


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.code (>= 0.7.0) and removes it from Remotes.