### PR TITLE
followup after TealAppDriver$initialize changes

### DIFF
--- a/tests/testthat/helper-TealAppDriver.R
+++ b/tests/testthat/helper-TealAppDriver.R
@@ -2,7 +2,7 @@ init_teal_app_driver <- function(...) {
   testthat::with_mocked_bindings(
     {
       TealAppDriver <- getFromNamespace("TealAppDriver", "teal") # nolint: object_name.
-      TealAppDriver$new(...)
+      TealAppDriver$new(teal::init(...))
     },
     shinyApp = function(ui, server, ...) {
       functionBody(server) <- bquote({


### PR DESCRIPTION
Followup after https://github.com/insightsengineering/teal/pull/1623
`TealAppDriver` now accepts `teal_app` instead of `data, modules, ...`
Please run the tests with `options(TESTING_DEPTH=5)`